### PR TITLE
Extend the `pkgConfig` and `json`(user config) objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -202,7 +202,7 @@ Config.prototype.init = function (pkgConfig) {
   if (pkgConfig) {
     this._pkgConfig = pkgConfig;
     json = this._readConfigurationFile();
-    keys = _.omit(_.extend(pkgConfig, json), this._blacklist);
+    keys = _.omit(_.extend(pkgConfig, json), _.union(this._blacklist, _.keys(json)));
     this.setKey(keys);
   }
 

--- a/index.js
+++ b/index.js
@@ -202,7 +202,7 @@ Config.prototype.init = function (pkgConfig) {
   if (pkgConfig) {
     this._pkgConfig = pkgConfig;
     json = this._readConfigurationFile();
-    keys = _.omit(pkgConfig, _.union(this._blacklist, _.keys(json)));
+    keys = _.omit(_.extend(pkgConfig, json), this._blacklist);
     this.setKey(keys);
   }
 


### PR DESCRIPTION
and then omit keys present in the blacklist